### PR TITLE
Use all-contributors-cli to generate contributors list

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,88 @@
 {
-  "imageSize": 100,
-  "projectOwner": "kentcdodds",
-  "projectName": "all-contributors"
+  "imageSize": 100
+, "projectOwner": "kentcdodds"
+, "projectName": "all-contributors"
+, "contributorsPerLine": 6
+, "contributors": [
+    {
+      "login": "kentcdodds"
+    , "name": "Kent C. Dodds"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/1500684?v=3"
+    , "profile": "http://kentcdodds.com"
+    , "contributions": [
+        "doc"
+      , "review"
+      , "question"
+      ]
+    }
+  , {
+      "login": "bogas04"
+    , "name": "Divjot Singh"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/6177621?v=3"
+    , "profile": "http://bogas04.github.io"
+    , "contributions": [
+        "doc"
+      , "review"
+      ]
+    }
+  , {
+      "login": "ben-eb"
+    , "name": "Ben Briggs"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/1282980?v=3"
+    , "profile": "http://beneb.info"
+    , "contributions": [
+        "doc"
+      , "review"
+      ]
+    }
+  , {
+      "login": "Jameskmonger"
+    , "name": "James Monger"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/2037007?v=3"
+    , "profile": "http://github.com/Jameskmonger"
+    , "contributions": [
+        "doc"
+      , "review"
+      ]
+    }
+  , {
+      "login": "jfmengels"
+    , "name": "Jeroen Engels"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/3869412?v=3"
+    , "profile": "https://github.com/jfmengels"
+    , "contributions": [
+        "doc"
+      , "tool"
+      , "review"
+      ]
+    }
+  , {
+      "login": "chrissimpkins"
+    , "name": "Chris Simpkins"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/4249591?v=3"
+    , "profile": "https://github.com/chrissimpkins"
+    , "contributions": [
+        "doc"
+      , "review"
+      ]
+    }
+  , {
+      "login": "fhemberger"
+    , "name": "Frederic Hemberger"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/153481?v=3"
+    , "profile": "http://github.com/fhemberger"
+    , "contributions": [
+        "doc"
+      ]
+    }
+  , {
+      "login": "frigginglorious"
+    , "name": "Daniel Kraft"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/3982200?v=3"
+    , "profile": "http://github.com/frigginglorious"
+    , "contributions": [
+        "doc"
+      ]
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ✨ All Contributors v1.0.0-beta.0 ✨
 
-[![Join the chat at https://gitter.im/kentcdodds/all-contributors](https://img.shields.io/badge/chat-on%20gitter-46BC99.svg?style=flat-square)](https://gitter.im/kentcdodds/all-contributors?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
+[![Join the chat at https://gitter.im/kentcdodds/all-contributors](https://img.shields.io/badge/chat-on%20gitter-46BC99.svg?style=flat-square)](https://gitter.im/kentcdodds/all-contributors?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This is a specification for recognizing contributors to an open source project in a way that rewards each and every contribution, not just code.
 
@@ -62,11 +65,11 @@ Emoji | Represents | Links to
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
-| [![Kent C. Dodds](https://avatars1.githubusercontent.com/u/1500684?s=100)<br /><sub>Kent C. Dodds</sub>](http://kentcdodds.com)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=kentcdodds) 👀 ❓ | [![Divjot Singh](https://avatars1.githubusercontent.com/u/6177621?s=100)<br /><sub>Divjot Singh</sub>](http://bogas04.github.io)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=bogas04) 👀 | [![Ben Briggs](https://avatars1.githubusercontent.com/u/1282980?v=3&s=100)<br /><sub>Ben Briggs</sub>](http://beneb.info)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=ben-eb) 👀 | [![James Monger](https://avatars1.githubusercontent.com/u/2037007?v=3&s=100)<br /><sub>James Monger</sub>](http://github.com/Jameskmonger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=Jameskmonger) | [![Jeroen Engels](https://avatars.githubusercontent.com/u/3869412?v=3&s=100)<br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=jfmengels) [🔧](https://www.npmjs.com/package/all-contributors-cli) 👀 | [![Chris Simpkins](https://avatars0.githubusercontent.com/u/4249591?v=3&s=100)<br /><sub>Chris Simpkins</sub>](http://github.com/chrissimpkins)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=chrissimpkins) 👀 | [![Frederic Hemberger](https://avatars0.githubusercontent.com/u/153481?v=3&s=100)<br /><sub>F. Hemberger</sub>](http://github.com/fhemberger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=fhemberger) | 
-| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-
-| [![Daniel Kraft](https://avatars1.githubusercontent.com/u/3982200?v=3&s=100)<br /><sub>Daniel Kraft</sub>](http://github.com/frigginglorious)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=frigginglorious) | 
-| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+| [![Kent C. Dodds](https://avatars.githubusercontent.com/u/1500684?v=3&s=100)<br /><sub>Kent C. Dodds</sub>](http://kentcdodds.com)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=kentcdodds) 👀 ❓ | [![Divjot Singh](https://avatars.githubusercontent.com/u/6177621?v=3&s=100)<br /><sub>Divjot Singh</sub>](http://bogas04.github.io)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=bogas04) 👀 | [![Ben Briggs](https://avatars.githubusercontent.com/u/1282980?v=3&s=100)<br /><sub>Ben Briggs</sub>](http://beneb.info)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=ben-eb) 👀 | [![James Monger](https://avatars.githubusercontent.com/u/2037007?v=3&s=100)<br /><sub>James Monger</sub>](http://github.com/Jameskmonger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=Jameskmonger) 👀 | [![Jeroen Engels](https://avatars.githubusercontent.com/u/3869412?v=3&s=100)<br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=jfmengels) 🔧 👀 | [![Chris Simpkins](https://avatars.githubusercontent.com/u/4249591?v=3&s=100)<br /><sub>Chris Simpkins</sub>](https://github.com/chrissimpkins)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=chrissimpkins) 👀 |
+| :---: | :---: | :---: | :---: | :---: | :---: |
+| [![Frederic Hemberger](https://avatars.githubusercontent.com/u/153481?v=3&s=100)<br /><sub>Frederic Hemberger</sub>](http://github.com/fhemberger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=fhemberger) | [![Daniel Kraft](https://avatars.githubusercontent.com/u/3982200?v=3&s=100)<br /><sub>Daniel Kraft</sub>](http://github.com/frigginglorious)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=frigginglorious) |
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
 Contributions of any kind welcome!


### PR DESCRIPTION
Update `README.md` and `.all-contributorsrc` to use [all-contributors-cli v2.0.0](https://github.com/jfmengels/all-contributors-cli).
It is currently in beta (`npm i -g all-contributors-cli@beta`).
- Contributors are listed in `.all-contributorsrc`, next to the generation settings.
- The generator uses the contributor list in `.all-contributorsrc` to generate the list of contributors (using `all-contributors generate`)
- If you want to modify the data of a contributor, do it in the rc file, then run the generator again.
- If you want to add a contributor, run `all-contributors add <githublogin> <contributions>`. For example `all-contributors add kentcdodds doc,review`. The contributor's data will be fetched from GitHub, and the avatar will link to his "blog" if available, otherwise to his github page).
- The badge count is updated at every generation.
- The tool uses comment tags, like `<!-- ALL-CONTRIBUTORS-LIST:START --><!-- ALL-CONTRIBUTORS-LIST:END -->` to find where to inject the contributor list and the badge list.
- I have added the possibility to define custom templates for most of the generations
- It's possible to configure the tool to go update multiple files, like README.md and CONTRIBUTORS.md. If for example, there is only the badge in the former and the contributor list in the latter, both will be updated (as long as the appropriate comment tags are present).

Let me know what you think!

[Preview of the README here](https://github.com/kentcdodds/all-contributors/blob/cli/README.md)
