### PR TITLE
docs(implementation): removed broken `tutorship` repo URL

### DIFF
--- a/docs/project/implementations.md
+++ b/docs/project/implementations.md
@@ -21,7 +21,6 @@ list, please [edit this page](contribute)!
 - [ta2edchimp/opt-cli](https://github.com/ta2edchimp/opt-cli)
 - [diegohaz/arc](https://github.com/diegohaz/arc)
 - [jccguimaraes/atom-project-viewer](https://github.com/jccguimaraes/atom-project-viewer)
-- [tutorship/tutorship](https://github.com/tutorship/tutorship)
 - [Angular Medellin Meetup](https://github.com/angular-medellin/meetup)
 - [React Medellin Meetup](https://github.com/react-medellin/meetup)
 - [jmeas/redux-resource](https://github.com/jmeas/redux-resource)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?)
Help in fixing #187 and co.

Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
 -->
**What**:
Removes a dead URL from a dead repo.
<!-- Why are these changes necessary? -->
**Why**:
Because having dead URLs which increase the broken link count (which is detrimental for SEO) is a bad idea (re #187).

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions --> N/A
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
