### PR TITLE
docs: Add skipCi documentation

### DIFF
--- a/docs/bot/configuration.md
+++ b/docs/bot/configuration.md
@@ -37,7 +37,7 @@ These are the keys you can specify:
       "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
     }
   },
-  "skipCi": 'true',
+  "skipCi": "true",
   "contributors": []
 }
 ```

--- a/docs/bot/configuration.md
+++ b/docs/bot/configuration.md
@@ -20,7 +20,7 @@ These are the keys you can specify:
 | `badgeTemplate`       | Define your own lodash template to generate the badge.                                              | |
 | `contributorTemplate` | Define your own lodash template to generate the contributor.                                        | |
 | `types`               | Specify custom symbols or link templates for contribution types. Can override the documented types. | |
-| `skipCi`              | Makes the CI ignore the commit. (or not, basically a suffix for the message)                        | Default: `[skip ci]` |
+| `skipCi`              | Makes the CI ignore the commit. (either `true` or `false`)                                          | Default: `true` |
 | `contributors`        | List of contributors for this project, this is updated by [@all-contributors add](usage#all-contributors-add) | |
 
 ```json
@@ -37,7 +37,7 @@ These are the keys you can specify:
       "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
     }
   },
-  "skipCi": '[skip ci]',
+  "skipCi": 'true',
   "contributors": []
 }
 ```

--- a/docs/bot/configuration.md
+++ b/docs/bot/configuration.md
@@ -20,6 +20,7 @@ These are the keys you can specify:
 | `badgeTemplate`       | Define your own lodash template to generate the badge.                                              | |
 | `contributorTemplate` | Define your own lodash template to generate the contributor.                                        | |
 | `types`               | Specify custom symbols or link templates for contribution types. Can override the documented types. | |
+| `skipCi`              | Makes the CI ignore the commit. (or not, basically a suffix for the message)                        | Default: `[skip ci]` |
 | `contributors`        | List of contributors for this project, this is updated by [@all-contributors add](usage#all-contributors-add) | |
 
 ```json
@@ -36,6 +37,7 @@ These are the keys you can specify:
       "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
     }
   },
+  "skipCi": '[skip ci]',
   "contributors": []
 }
 ```


### PR DESCRIPTION
> In reference to #281 and [this PR](https://github.com/all-contributors/all-contributors-bot/pull/216).

Add the usage of `skipCi` to the bot configuration page.

- [x] Documentation
- [x] Ready to be merged, *IMHO*
- [ ] Added myself to contributors table. <as is optional>

-------
as of today [PR of reference](https://github.com/all-contributors/all-contributors-bot/pull/216) is not merged, so maybe we should wait until that happens.