### PR TITLE
docs: add docs for badge not updating correctly

### DIFF
--- a/docs/bot/faq.md
+++ b/docs/bot/faq.md
@@ -1,0 +1,24 @@
+---
+id: faq
+title: Frequently Asked Questions
+sidebar_label: FAQs
+---
+
+## All Contributors badge count, does not update?
+To have the Badge update correctly, you must wrap your badge in start and end tags (as also done from the contribution table)
+
+**Previously**
+```markdown
+[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
+```
+
+**Now**
+```markdown
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
+<!-- ALL-CONTRIBUTORS-BADGE:END --> 
+```
+
+
+
+

--- a/docs/bot/overview.md
+++ b/docs/bot/overview.md
@@ -22,6 +22,7 @@ Enter the `@all-contributors bot`! The bot will automatically pull a user's prof
 - [Installing the Bot](installation)
 - [Using the Bot](usage)
 - [Configuring the Bot](configuration)
+- [Frequently Asked Questions](faq)
 
 
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
       "bot/overview",
       "bot/installation",
       "bot/usage",
-      "bot/configuration"
+      "bot/configuration",
+      "bot/faq"
     ],
     "CLI": [
       "cli/overview",


### PR DESCRIPTION
Adding basic documentation for breaking change which will now be live in bot (going in, in https://github.com/all-contributors/all-contributors-bot/pull/263)

## Breaking Change Summary
Introduce in https://github.com/all-contributors/all-contributors-cli/pull/210

All Contributors badge will no longer be updated unless they wrap their badge in the following tags
```
<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
BADGE
<!-- ALL-CONTRIBUTORS-BADGE:END --> 