### PR TITLE
docs: fix contributor template example using undefined avatarBlock

### DIFF
--- a/docs/bot/configuration.md
+++ b/docs/bot/configuration.md
@@ -29,7 +29,7 @@ These are the keys you can specify:
   "imageSize": 100,
   "contributorsPerLine": 7,
   "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
-  "contributorTemplate": "<%= avatarBlock %><br /><%= contributions %>",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
   "types": {
     "custom": {
       "symbol": "🔭",

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -38,7 +38,7 @@ These are the keys you can specify:
   "commit": false,
   "contributorsPerLine": 7,
   "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
-  "contributorTemplate": "<%= avatarBlock %><br /><%= contributions %>",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
   "types": {
     "custom": {
       "symbol": "🔭",


### PR DESCRIPTION
**What**: For https://github.com/all-contributors/all-contributors-cli/issues/237. 
 
The documentation is referencing `<%= avatarBlock %>`, which, if used, leads to an `avatarBlock is not defined` error.

**Why**: The current documentation on how-to override the default `contributorTemplate` comes with an erroneous variable and doesn't give visibility on what variables are available to the formatter.

**How**: Using the correct variables used by the default `contributorTemplate` as an example.

**Checklist**:
- [x] Documentation
- [x] Ready to be merged
- [x] Added myself to contributors table