### PR TITLE
docs: added an emoji-key for audio content

### DIFF
--- a/docs/emoji-key.md
+++ b/docs/emoji-key.md
@@ -10,6 +10,7 @@ sidebar_label: Emoji Key ✨
 
 Emoji/Type | Represents | Comments
 :---: | :---: | :---:
+🔊 <br /> `audio` | Audio | Podcasts, background music or sound effects
 ♿️ <br /> `a11y` | Accessibility | Reporting or working on accessibility issues
 🐛 <br /> `bug` | Bug reports | links to issues reported by the user on this project
 📝 <br /> `blog` | Blogposts | links to the blogpost


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?)

This PR adds an contribution type for audio content. This includes podcasts, background music and sound effects. It is analogous to the existing keys for video and design/graphics.

<!-- Why are these changes necessary? -->
**Why**:
It is strange that there is a key for design (which is a paint pallet) and one for video but none for audio. 

Audio content such as podcasts are important to spread the word about a project. For certain projects sound effects and background musics are also important (for example https://github.con/arianne/stendhal)

<!-- How were these changes implemented? -->
**How**:
An entry to the emoji key documentation page was added.

<!-- Have you done all of these things?  -->
**Checklist**:
- [X] Documentation
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? 

