### PR TITLE
docs: missing mandatory bot mention in example

### DIFF
--- a/docs/bot/usage.md
+++ b/docs/bot/usage.md
@@ -24,7 +24,7 @@ The bot will then create a Pull Request to add the contributor, then reply with 
 > Your request to the bot doesn't need to be perfect. The bot will use [basic Natural Language Parsing](https://github.com/all-contributors/all-contributors-bot/blob/master/src/tasks/processIssueComment/utils/parse-comment/index.js) to determine your intent.
 > For example, this will work too:
 >
-> `Jane you are crushing it in documentation and your infrastructure work has been great too. Let's add jane.doe23 for her contributions. cc @all-contributors`
+> `Jane you are crushing it in documentation and your infrastructure work has been great too. Let's add jane.doe23 for her contributions. cc @all-contributors bot`
 
 ## What's next
 - [Configuring the Bot](configuration)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the [Code of Conduct](https://allcontributors.org/docs/en/project/code-of-conduct) for this project.

Also, please make sure you're familiar with and follow the instructions in the
[contributing guidelines](https://github.com/all-contributors/all-contributors/blob/master/CONTRIBUTING.md) (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?)

e.g. Fixes #0

Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
 -->
**What**:
Trying the example from the documentation for bot usage, outlines an example that would work as an alternative, but it is missing the word "bot" after the `@all-contributors` mention as `@all-contributors bot`.
<!-- Why are these changes necessary? -->
**Why**:
For this to work, this seems to be required yet.
<!-- How were these changes implemented? -->
**How**:
Updated the documentation accordingly.
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
