### PR TITLE
docs(emoji-key): add research contribution type

### DIFF
--- a/docs/emoji-key.md
+++ b/docs/emoji-key.md
@@ -32,7 +32,7 @@ Emoji/Type | Represents | Comments
 🔌 <br /> `plugin` | Plugin/utility libraries | Links to the repo home
 📆 <br/> `projectManagement` | Project Management | |
 💬 <br /> `question` | Answering Questions | Answering Questions in Issues, Stack Overflow, Gitter, Slack, etc.
-:microscope: <br /> `research` | Research | Literature review and code prototyping.
+🔬 <br /> `research` | Research | Literature review.
 👀 <br /> `review` | Reviewed Pull Requests | |
 🛡️ <br /> `security` | Security | Identify and/or reduce security threats, GDPR, Privacy, etc
 🔧 <br /> `tool` | Tools | Links to the repo home

--- a/docs/emoji-key.md
+++ b/docs/emoji-key.md
@@ -32,6 +32,7 @@ Emoji/Type | Represents | Comments
 🔌 <br /> `plugin` | Plugin/utility libraries | Links to the repo home
 📆 <br/> `projectManagement` | Project Management | |
 💬 <br /> `question` | Answering Questions | Answering Questions in Issues, Stack Overflow, Gitter, Slack, etc.
+:microscope: <br /> `research` | Research | Literature review and code prototyping.
 👀 <br /> `review` | Reviewed Pull Requests | |
 🛡️ <br /> `security` | Security | Identify and/or reduce security threats, GDPR, Privacy, etc
 🔧 <br /> `tool` | Tools | Links to the repo home


### PR DESCRIPTION
**What**:
Add a research contribution type with microscope emoji, for people doing literature review, code
prototyping or any other research-related activity.

Part 1/3 for #446 

**Why**:
For open science projects or dev projects with a research component, people carrying out research tasks cannot always be acknowledged with the existing types.

**How**:
Adding the type description to the emoji key.

**Checklist**:
- [x] Documentation
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table.

CLI and bot PRs are following.
