### PR TITLE
docs: ✏️ add bradgarropy/hue-sdk to projects

### DIFF
--- a/docs/project/implementations.md
+++ b/docs/project/implementations.md
@@ -35,6 +35,7 @@ list, please [edit this page](contribute)!
 - [tstrohmeier/docker-spark-development](https://github.com/tstrohmeier/docker-spark-development)
 - [jakewies/hugo-theme-codex](https://github.com/jakewies/hugo-theme-codex)
 - [persian-tools/persian-tools](https://github.com/persian-tools/persian-tools)
+- [bradgarropy/hue-sdk](https://github.com/bradgarropy/hue-sdk)
 
 **Note**: There are many projects not listed here. You'll probably be able to find more with this
 [github search for .all-contributorsrc](https://github.com/search?utf8=%E2%9C%93&q=.all-contributorsrc+in%3Apath&type=Code&ref=searchresults)


### PR DESCRIPTION
**What**: Add `bradgarropy/hue-sdk` to the list of projects.

**Why**: Increases social proof that `all-contributors` is awesome!

**How**: Modified the `implementations.md` file to include a link to `bradgarropy/hue-sdk`.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Ready to be merged
- [x] Added myself to contributors table.