### PR TITLE
ci(config): update the node image in CirceCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 docker_defaults: &docker_defaults
   docker:
-    - image: circleci/node:8.14.0
+    - image: circleci/node:12.0.0
 
 commands:
   prep_env:


### PR DESCRIPTION
**What**:
Bumps the Node image in the CirceCI config.

<!-- Why are these changes necessary? -->
**Why**:
To tackle the [failing build](https://github.com/all-contributors/all-contributors/runs/2336473172)
following the _successful_ merge of #514

<!-- How were these changes implemented? -->
**How**:


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
