### PR TITLE
docs: prefer dynamic badge over bot-updated static badge (#406)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 [![Build Status](https://img.shields.io/circleci/project/all-contributors/all-contributors/master.svg)](https://circleci.com/gh/all-contributors/workflows/all-contributors/tree/master)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/all-contributors/localized.svg)](https://crowdin.com/project/all-contributors)
-[![All Contributors](https://img.shields.io/badge/all_contributors-54-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/github/all-contributors/all-contributors/all-contributors?color=ee8449&style=flat-square)](#contributors-)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e30784c5-9efd-4f20-8a47-13f3fb899613/deploy-status)](https://app.netlify.com/sites/allcontributors-org/deploys)
 [![Star on GitHub](https://img.shields.io/github/stars/all-contributors/all-contributors.svg?style=social)](https://github.com/all-contributors/all-contributors/stargazers)
 

--- a/docs/bot/configuration.md
+++ b/docs/bot/configuration.md
@@ -42,7 +42,7 @@ These are the keys you can specify:
   "commit": false,
   "contributorsPerLine": 7,
   "contributorsSortAlphabetically": false,
-  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/github/all-contributors/<%= projectOwner %>/<%= projectName %>?color=ee8449&style=flat-square)](#contributors)",
   "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
   "types": {
     "custom": {

--- a/docs/bot/faq.md
+++ b/docs/bot/faq.md
@@ -6,18 +6,20 @@ sidebar_label: FAQs
 
 ### All Contributors badge count, does not update?
 
-To have the Badge update correctly, you must wrap your badge in start and end tags (as also done from the contribution table)
+To have the Badge update correctly, use the dynamic Shields badge.
 
 #### Previously
 
 ```markdown
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 ```
 
 #### Now
 
+Replace `projectOwner` with the relevant GitHub username or organization name, and `projectName` with the relevant the GitHub repo name. Style, color, and other parameters can be customized to your liking — see <https://shields.io/>.
+
 ```markdown
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
-<!-- ALL-CONTRIBUTORS-BADGE:END --> 
+[![All Contributors](https://img.shields.io/github/all-contributors/projectOwner/projectName?color=ee8449&style=flat-square)](#contributors)
 ```

--- a/docs/bot/installation.md
+++ b/docs/bot/installation.md
@@ -43,12 +43,10 @@ For the list:
 
 Note: Extra line is very important in order to make it work properly.
 
-For the badge:
+For the badge use the following, replacing `projectOwner` with the relevant GitHub username or organization name, and `projectName` with the relevant the GitHub repo name. Style, color, and other parameters can be customized to your liking — see <https://shields.io/>.
 
 ```markdown
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![All Contributors](https://img.shields.io/github/all-contributors/projectOwner/projectName?color=ee8449&style=flat-square)](#contributors)
 ```
 
 ## 4. Update your Contributing documentation


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the [Code of Conduct](https://allcontributors.org/docs/en/project/code-of-conduct) for this project.

Also, please make sure you're familiar with and follow the instructions in the
[contributing guidelines](https://github.com/all-contributors/all-contributors/blob/master/CONTRIBUTING.md) (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?)



Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
 -->
**What**: updates the badge documentation to prefer the dynamic badge (h/t @JoeIzzard) over the bot-managed static badge.
- #406

<!-- Why are these changes necessary? -->
**Why**: there have been problems related to the static badge (for example, as of this writing the live README's static badge says 54, but it should say 98), and it does not support custom styling that survives the bot-managed update.

<!-- How were these changes implemented? -->
**How**: updates docs. Intentionally does _not_ drop support for the bot-managed badge.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)
  - Looks like the maintainers have been managing this with comments in contributor PRs. In addition to adding me if this PR is accepted, consider adding JoelIzzard for his contributing the All Contributors shield to Shields https://github.com/all-contributors/all-contributors/issues/406?show_full=true#issue-630711906