### PR TITLE
docs: add vanityURLs to implementations.md

### DIFF
--- a/docs/project/implementations.md
+++ b/docs/project/implementations.md
@@ -45,6 +45,7 @@ list, please [edit this page](contribute)!
 - [Taiizor/ReaLTaiizor](https://github.com/Taiizor/ReaLTaiizor)
 - [Soferity/Witcher](https://github.com/Soferity/Witcher)
 - [Schrodinger-Hat/youtube-to-anchorfm](https://github.com/Schrodinger-Hat/youtube-to-anchorfm)
+- [vanityURLs](https://github.com/bhdicaire/vanityURLs)
 
 **Note**: There are many projects not listed here. You'll probably be able to find more with this
 [github search for .all-contributorsrc](https://github.com/search?utf8=%E2%9C%93&q=.all-contributorsrc+in%3Apath&type=Code&ref=searchresults)


### PR DESCRIPTION
**What**:  
Added VanityURLs to the list

**Why**: 
We're supporting all-contributors

**Checklist**:

- [x]  Documentation
- [x]  Ready to be merged