### PR TITLE
chore(ci): add dependabot config for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
closes #859 

This pr adds a config file for dependabot so it can update our actions once a month with the most recent security updates.
I don't want to implement this yet for npm because we have some big updates to do there first and any updates might break things right now. 

**What**:

Security updates for actions are important :)

**Why**:
I added a Yml file that we can use to configure dependabot.

**How**:

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table.  


We could add dependabot to our docs. It isn't there now and I haven't added it in the past but please let me know if you think we should add it. 
