### PR TITLE
chore(dep): update crowdin dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,10 @@
         "all-contributors": "index.js"
       },
       "devDependencies": {
+        "@crowdin/cli": "^4.11.0",
         "broken-link-checker": "^0.7.8",
         "cz-conventional-changelog": "^2.1.0",
-        "docusaurus": "^1.7.3",
+        "docusaurus": "^1.7.4",
         "git-cz": "^4.1.0",
         "react": "^16.6.3",
         "semantic-release": "^19.0.3"
@@ -1655,6 +1656,50 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@crowdin/cli": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@crowdin/cli/-/cli-4.11.0.tgz",
+      "integrity": "sha512-oIOzCHCc9eHOqcQw1bjcnfFUoJDFVobCN5MEZ1rwjYOhPMpIcRNBDnUT/b43LcRWsogU3c0BwcWN/BHvV19DWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "command-exists-promise": "^2.0.2",
+        "node-fetch": "2.7.0",
+        "shelljs": "^0.8.5",
+        "tar": "^7.4.3",
+        "yauzl": "^3.2.0"
+      },
+      "bin": {
+        "crowdin": "jdeploy-bundle/jdeploy.js"
+      }
+    },
+    "node_modules/@crowdin/cli/node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4342,6 +4387,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4691,6 +4746,16 @@
         "bluebird": "^2.8.1",
         "debug": "^2.1.1",
         "stream-length": "^1.0.1"
+      }
+    },
+    "node_modules/command-exists-promise": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/command-exists-promise/-/command-exists-promise-2.0.2.tgz",
+      "integrity": "sha512-T6PB6vdFrwnHXg/I0kivM3DqaCGZLjjYSOe0a5WgFKcz1sOnmOeIjnhQPXVXX3QjVbLyTJ85lJkX6lUpukTzaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/commander": {
@@ -10959,6 +11024,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mixin-deep": {
@@ -19081,6 +19169,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -19098,6 +19204,32 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tcp-port-used": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "commit": "git-cz"
   },
   "devDependencies": {
+    "@crowdin/cli": "^4.11.0",
     "broken-link-checker": "^0.7.8",
     "cz-conventional-changelog": "^2.1.0",
     "docusaurus": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "cd website && ../node_modules/.bin/docusaurus-start",
     "build": "cd website && ../node_modules/.bin/docusaurus-build && cp _redirects build/all-contributors",
     "write-translations": "cd website && ../node_modules/.bin/docusaurus-write-translations",
-    "crowdin": "java -jar website/crowdin/crowdin-cli.jar",
+    "crowdin": "npx crowdin-cli",
     "crowdin-upload": "npm run crowdin -- --config crowdin.yaml upload sources --auto-update -b $(git rev-parse --abbrev-ref HEAD)",
     "crowdin-download": "npm run crowdin -- --config crowdin.yaml download -b $(git rev-parse --abbrev-ref HEAD)",
     "build-with-translations": "npm run write-translations && npm run crowdin-upload && npm run crowdin-download && npm run build",


### PR DESCRIPTION
closes #855 

I looked at the netlify deploy logs and noticed it was erroring when trying to run the crowdin cli. Our current dependency was a few versions older. So this fixes that issue and moves crowdin to npm install crowdin-cli instead of the java jar route. 

**What**:
Netlify is not building because of dated /deprecated dependencies.

**Why**:
A simple dependency update!

 **How**:

**Checklist**:

- [ ] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

