### PR TITLE
docs(readme): sync readme file in docs upgrade branch with main 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1069,6 +1069,15 @@
       "contributions": [
         "review"
       ]
+    },
+    {
+      "login": "JHWelch",
+      "name": "Jordan Welch",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4480375?v=4",
+      "profile": "http://jordanwelch.com/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Thanks go to these wonderful people ([emoji key](https://allcontributors.org/doc
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://elmthomas.com"><img src="https://avatars.githubusercontent.com/u/58678?v=4?s=100" width="100px;" alt="Eric Thomas"/><br /><sub><b>Eric Thomas</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors/commits?author=et" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://blog.jmadge.com"><img src="https://avatars.githubusercontent.com/u/23616154?v=4?s=100" width="100px;" alt="Jim Madge"/><br /><sub><b>Jim Madge</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors/pulls?q=is%3Apr+reviewed-by%3AJimMadge" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://jordanwelch.com/"><img src="https://avatars.githubusercontent.com/u/4480375?v=4?s=100" width="100px;" alt="Jordan Welch"/><br /><sub><b>Jordan Welch</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors/commits?author=JHWelch" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR cherry picks the commits to the README file that I've merged into main. I'm making sure we don't lose all the contributors' bot additions to the file. I forgot that we should be merging into docs-upgrade to keep that current. 

**What**:

A tiny pr to sync our readme file to ensure we don't lose contributors there.

**Why**:
Because i've been adding new contributors as we merge things and we have 3 missing commits in our readme file.
This is a small fix

**How**:
I cherry picked the 3 commits that are missing in our current branch.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table.NA

<!-- feel free to add additional comments -->
