### PR TITLE
chore(ci for docs): Get docs online via github pages

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - docs-upgrade
 jobs:
   build:
     name: Build Astro site

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-
 import sitemap from '@astrojs/sitemap';
-
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://allcontributors.org',
-  base: '/',
+  base: '/all-contributors/',
   output: 'static',
 
   redirects: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,8 +5,8 @@ import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  site: 'https://allcontributors.org',
-  base: '/all-contributors/',
+  site: 'https://all-contributors.github.io',
+  base: '/all-contributors',
   output: 'static',
 
   redirects: {


### PR DESCRIPTION
Currently, the documentation is building from main branch which means that it is broken. I suggest (but want feedback) that is we merge this PR, we can test the docs live from the docs-upgrade branch. And moving forward, we can then merge into main sooner. 

This works here: https://www.leahwasser.com/all-contributors/ 

**What**:
I think because the docs are so broken online, it might be better to get the new site online sooner with all of the pages working (but broken links and images). Then we can focus the next pr's on fixing image links (which should not take too much time). 

**Why**:
Here, I modified CI build to deploy to github pages from docs-upgrade rather than main. I kept all-contributors/ as a baseurl because we should wait to ensure the page launches from github pages before fully commiting to updating main and renaming the repo (which will break netlify fully). 

**How**:

I am opening this as a quick draft and will open a discussion about it next. 

- [x] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
