### PR TITLE
ci(deps): add dependabot groups for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,17 @@
 
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      dependencies:
+        dependency-type: production
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Adds dependabot groups for NPM packages. This should,

- open two PRs for NPM package updates per week (if required)
- group npm updates into dependencies and dev dependencies

Hopefully this helps rationalise the PRs from dependabot and make them more manageable.