### PR TITLE
ci(crowdin): sync sources with Crowdin on merge to main

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -1,0 +1,25 @@
+name: Sync translations
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  sync-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: /actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Upload sources
+        uses: crowdin/github-action@5587c43 # v2.14.1
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          crowdin_branch_name: main
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
A workflow is added to keep Crowdin sources in sync with the state of the repo on the main branch

fixes #926
depends on #1025 #1026